### PR TITLE
remove doubled path segment in prepend function

### DIFF
--- a/Classes/Helper/BaseUrl.php
+++ b/Classes/Helper/BaseUrl.php
@@ -91,9 +91,11 @@ class BaseUrl
         }
         $relativeUri = new Uri($relativePath);
         $baseUri = $baseUrl ? new Uri($baseUrl) : self::get($identifier, $pageId, $explicit, false);
-
+        if (strpos($relativeUri->getPath(), $baseUri->getPath()) === 0) {
+            $redundantBaseUriPath = true;
+        }
         $absoluteUri = $baseUri
-            ->withPath($baseUri->getPath() . $relativeUri->getPath())
+            ->withPath(($redundantBaseUriPath ? '' : $baseUri->getPath()) . $relativeUri->getPath())
             ->withQuery($relativeUri->getQuery())
             ->withFragment($relativeUri->getFragment());
 


### PR DESCRIPTION
There are cases when baseURI and relativeURI contain the same segment (if T3 is not run directly in the DOCROOT). Remove redundant path when prepending.